### PR TITLE
adds support for `map-from-coll` that converts a collection to a map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-## 0.5.5 
+## 0.5.6
+ * Adds support for `map-from-coll` that converts a collection to a map.
+
+## 0.5.5
  * Bump schema dependency to avoid issues with Clojure 1.9 out of the box.
 
 ## 0.5.4

--- a/src/plumbing/core.cljx
+++ b/src/plumbing/core.cljx
@@ -93,6 +93,11 @@
   [f vs]
   (for-map [v vs] (f v) v))
 
+(defn map-from-coll
+  "Build map (f e) -> (g e) for elements in es"
+  [f g es]
+  (for-map [e es] (f e) (g e)))
+
 (defn dissoc-in
   "Dissociate this keyseq from m, removing any empty maps created as a result
    (including at the top-level)."

--- a/test/plumbing/core_test.cljx
+++ b/test/plumbing/core_test.cljx
@@ -71,6 +71,14 @@
   (is (= (p/map-from-vals inc [0 1 2])
          {1 0, 2 1, 3 2})))
 
+(deftest map-from-coll-test
+  (is (= (p/map-from-coll inc identity [0 1 2])
+         {1 0, 2 1, 3 2}))
+  (is (= (p/map-from-coll identity inc [0 1 2])
+         {0 1, 1 2, 2 3}))
+  (is (= (-> (p/map-from-coll #(mod % 3) inc [0 1 2 3 4]) keys set)
+         #{0 1 2})))
+
 (deftest dissoc-in-test
   (is (= {:a 1} (p/dissoc-in {:a 1 :b 2} [:b])))
   (is (= {:a 1 :b {:d 3}} (p/dissoc-in {:a 1 :b {:c 2 :d 3}} [:b :c])))


### PR DESCRIPTION
`(map-from-coll f g es)` builds a map `(f e) -> (g e)` for elements `e` in `es`.